### PR TITLE
Use `preferredLocalizations` instead of `preferredLanguages`.

### DIFF
--- a/deko/DekoLocalizationManager.m
+++ b/deko/DekoLocalizationManager.m
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSInteger, DekoLanguageType)
 {
 	if ((self = [super init]))
 	{
-		NSString *language = [NSLocale preferredLanguages][0];
+		NSString *language = [[NSBundle mainBundle] preferredLocalizations][0];
 		if ([language isEqualToString:@"zh-Hans"])
 		{
 			_currentLanguage = DekoLanguageTypeChina;


### PR DESCRIPTION
This should ensure that the correct fonts and such are used. Fixes https://github.com/superjohan/deko/issues/14.